### PR TITLE
Adjusted deprecation from region to location

### DIFF
--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,0 +1,2 @@
+# node-pool-v1.0.1
+- Change deprecation of region to conform to `location` parameter (Non-breaking change, resources should be safe)

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -26,7 +26,7 @@ resource "random_id" "entropy" {
 resource "google_container_node_pool" "node_pool" {
   name               = "${var.name}-${random_id.entropy.hex}"
   cluster            = "${var.gke_cluster_name}"
-  region             = "${var.region}"
+  location           = "${var.region}"
   version            = "${var.kubernetes_version}"
   initial_node_count = 1
 

--- a/public-vpc-native/CHANGELOG.md
+++ b/public-vpc-native/CHANGELOG.md
@@ -1,0 +1,2 @@
+# public-vpc-native-v1.0.1
+- Change deprecation of region to conform to `location` parameter (Non-breaking change, resources should be safe)

--- a/public-vpc-native/main.tf
+++ b/public-vpc-native/main.tf
@@ -1,6 +1,6 @@
 resource "google_container_cluster" "cluster" {
   name               = "${var.name}"
-  region             = "${var.region}"
+  location           = "${var.region}"
   min_master_version = "${var.kubernetes_version}"
   network            = "${var.network_name}"
   subnetwork         = "${var.nodes_subnetwork_name}"


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md#230-march-26-2019

Deprecated as of March. It is a non-breaking change for this module and will not want to recreate the resources.

Suggested tagging:
public-vpc-native-v1.0.1
node-pool-v1.0.1