### PR TITLE
Added the ability to set labels on instances in a node pool

### DIFF
--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,6 +1,7 @@
 # node-pool-v2.1.0
 - Added the ability to add labels to nodes in a node pool _WILL RECREATE YOUR NODE POOL_! Use this option carefully!
 - Added disk type to the node pool. Accepts the values 'pd-standard' or 'pd-ssd' _WILL RECREATE YOUR NODE POOL_! Use this option carefully!
+- Changing to this version will _WILL RECREATE YOUR NODE POOL_!
 
 # node-pool-v1.0.1
 - Change deprecation of region to conform to `location` parameter (Non-breaking change, resources should be safe)

--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,2 +1,5 @@
+# node-pool-v1.1.0
+- Added the ability to add labels to nodes in a node pool
+
 # node-pool-v1.0.1
 - Change deprecation of region to conform to `location` parameter (Non-breaking change, resources should be safe)

--- a/node_pool/README.md
+++ b/node_pool/README.md
@@ -68,6 +68,18 @@ Type: `string`
 
 Default: `"n1-standard-4"`
 
+#### node\_labels
+
+Description: Labels to add to the nodes in the pool
+
+Type: `map`
+
+Default:
+
+```json
+{}
+```
+
 
 ## Future To-do Items
 

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -41,3 +41,8 @@ variable "taint" {
   description = "Add a taint to the nodes in the pool"
   default     = {}
 }
+
+variable "disk_type" {
+  description = "Type of the disk attached to each node"
+  default     = "pd-standard"
+}

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -36,3 +36,8 @@ variable "node_labels" {
   description = "Labels to add to the nodes in the pool"
   default     = {}
 }
+
+variable "taint" {
+  description = "Add a taint to the nodes in the pool"
+  default     = {}
+}

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -31,3 +31,8 @@ variable "disk_size_in_gb" {
   description = "Disk size, in GB, for the nodes in the pool."
   default     = "100"
 }
+
+variable "node_labels" {
+  description = "Labels to add to the nodes in the pool"
+  default     = {}
+}

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -40,6 +40,7 @@ resource "google_container_node_pool" "node_pool" {
     disk_size_gb = "${var.disk_size_in_gb}"
     machine_type = "${var.machine_type}"
     labels       = "${var.node_labels}"
+    taint        = "${var.taint}"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/devstorage.read_only",

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -42,6 +42,7 @@ resource "google_container_node_pool" "node_pool" {
     machine_type = "${var.machine_type}"
     labels       = "${var.node_labels}"
     taint        = ["${var.taint}"]
+    disk_type    = "${var.disk_type}"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/devstorage.read_only",

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -41,7 +41,7 @@ resource "google_container_node_pool" "node_pool" {
     disk_size_gb = "${var.disk_size_in_gb}"
     machine_type = "${var.machine_type}"
     labels       = "${var.node_labels}"
-    taint        = "${var.taint}"
+    taint        = ["${var.taint}"]
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/devstorage.read_only",

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -24,7 +24,7 @@ resource "random_id" "entropy" {
 }
 
 resource "google_container_node_pool" "node_pool" {
-  provider           = "google-beta"
+  # provider           = "google-beta"
   name               = "${var.name}-${random_id.entropy.hex}"
   cluster            = "${var.gke_cluster_name}"
   location           = "${var.region}"
@@ -41,7 +41,7 @@ resource "google_container_node_pool" "node_pool" {
     disk_size_gb = "${var.disk_size_in_gb}"
     machine_type = "${var.machine_type}"
     labels       = "${var.node_labels}"
-    taint        = "${var.taint}"
+    # taint        = "${var.taint}"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/devstorage.read_only",

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -41,7 +41,7 @@ resource "google_container_node_pool" "node_pool" {
     disk_size_gb = "${var.disk_size_in_gb}"
     machine_type = "${var.machine_type}"
     labels       = "${var.node_labels}"
-    # taint        = "${var.taint}"
+    taint        = "${var.taint}"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/devstorage.read_only",

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -24,6 +24,7 @@ resource "random_id" "entropy" {
 }
 
 resource "google_container_node_pool" "node_pool" {
+  provider           = "google-beta"
   name               = "${var.name}-${random_id.entropy.hex}"
   cluster            = "${var.gke_cluster_name}"
   location           = "${var.region}"

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -39,6 +39,7 @@ resource "google_container_node_pool" "node_pool" {
     image_type   = "COS"
     disk_size_gb = "${var.disk_size_in_gb}"
     machine_type = "${var.machine_type}"
+    labels       = "${var.node_labels}"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/devstorage.read_only",

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -24,7 +24,6 @@ resource "random_id" "entropy" {
 }
 
 resource "google_container_node_pool" "node_pool" {
-  # provider           = "google-beta"
   name               = "${var.name}-${random_id.entropy.hex}"
   cluster            = "${var.gke_cluster_name}"
   location           = "${var.region}"

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -18,6 +18,8 @@ resource "random_id" "entropy" {
     name         = "${var.name}"
     region       = "${var.region}"
     disk_size    = "${var.disk_size_in_gb}"
+    disk_type    = "${var.disk_type}"
+    labels       = "${jsonencode(var.node_labels)}"
   }
 
   byte_length = 2

--- a/node_pool_taint/CHANGELOG.md
+++ b/node_pool_taint/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Added the ability to add labels to nodes in a node pool _WILL RECREATE YOUR NODE POOL_! Use this option carefully!
 - Added disk type to the node pool. Accepts the values 'pd-standard' or 'pd-ssd' _WILL RECREATE YOUR NODE POOL_! Use this option carefully!
 - Added the ability to add taints to nodes in the node pool. Taints require the google-beta providor. WILL RECREATE YOUR NODE POOL_! Use this option carefully!
+- Changing to this version will _WILL RECREATE YOUR NODE POOL_!

--- a/node_pool_taint/CHANGELOG.md
+++ b/node_pool_taint/CHANGELOG.md
@@ -1,6 +1,4 @@
-# node-pool-v2.1.0
+# node-pool-taint-v2.1.0
 - Added the ability to add labels to nodes in a node pool _WILL RECREATE YOUR NODE POOL_! Use this option carefully!
 - Added disk type to the node pool. Accepts the values 'pd-standard' or 'pd-ssd' _WILL RECREATE YOUR NODE POOL_! Use this option carefully!
-
-# node-pool-v1.0.1
-- Change deprecation of region to conform to `location` parameter (Non-breaking change, resources should be safe)
+- Added the ability to add taints to nodes in the node pool. Taints require the google-beta providor. WILL RECREATE YOUR NODE POOL_! Use this option carefully!

--- a/node_pool_taint/Makefile
+++ b/node_pool_taint/Makefile
@@ -1,0 +1,15 @@
+# This constructs README.md, including Terraform documentation in its middle.
+# THIs requires `terraform-docs` to be installed from: https://github.com/segmentio/terraform-docs
+
+# The sed command below increases the markdown heading level of Terraform docs.
+README.md:README.pre_terraform_inputs.md README.post_terraform_inputs.md
+	@echo Creating ReadMe with Terraform docs. . .
+	cat README.pre_tf_inputs.md >README.md
+	echo >>README.md
+	terraform-docs --with-aggregate-type-defaults md document . |sed 's/^#/##/g' >>README.md
+	echo >>README.md
+	cat README.post_tf_inputs.md >>README.md
+
+README.pre_terraform_inputs.md:
+README.post_terraform_inputs.md:
+

--- a/node_pool_taint/README.md
+++ b/node_pool_taint/README.md
@@ -1,0 +1,104 @@
+# Terraform GKE Node Pool Module
+
+This module manages a node pool attached to a Google Kubernetes Engine (GKE) cluster.
+
+## Using The Terraform Module
+
+This module requires version 2.0.0 or above of the Google Terraform provider.
+
+See the file [example-usage](./example-usage) for an example of how to use this module. Below are the available module inputs:
+
+### Required Inputs
+
+The following input variables are required:
+
+#### gke\_cluster\_name
+
+Description: The name of the GKE cluster to bind this node pool.
+
+Type: `string`
+
+#### kubernetes\_version
+
+Description: The kubernetes version for the nodes in the pool. This should match the Kubernetes version of the GKE cluster.
+
+Type: `string`
+
+#### max\_node\_count
+
+Description: Maximum number of nodes for autoscaling, per availability zone.
+
+Type: `string`
+
+#### min\_node\_count
+
+Description: Minimum number of nodes for autoscaling, per availability zone.
+
+Type: `string`
+
+#### name
+
+Description: The name of the node pool. A random string will be appended to this name, to allow replacement node pools to be created before destroying the current pool.
+
+Type: `string`
+
+#### region
+
+Description: The region for the node pool.
+
+Type: `string`
+
+#### taint
+
+Description: Add a taint to the nodes in the pool
+
+Type: `string`
+
+### Optional Inputs
+
+The following input variables are optional (have default values):
+
+#### disk\_size\_in\_gb
+
+Description: Disk size, in GB, for the nodes in the pool.
+
+Type: `string`
+
+Default: `"100"`
+
+#### disk\_type
+
+Description: Type of the disk attached to each node
+
+Type: `string`
+
+Default: `"pd-standard"`
+
+#### machine\_type
+
+Description: The machine type of nodes in the pool.
+
+Type: `string`
+
+Default: `"n1-standard-4"`
+
+#### node\_labels
+
+Description: Labels to add to the nodes in the pool
+
+Type: `map`
+
+Default:
+
+```json
+{}
+```
+
+
+## Future To-do Items
+
+* Perform additional testing  of conditions that will cause Terraform to recreate the node pool, based on the `keeper`s defined in the `random_id` resource.
+* Determine whether, depending on results from the above testing, the node pool should have a `create_before_destroy` lifecycle.
+* Do we want to be able to enable auto-upgrade on node pools?
+* Do we want to be able to set taints on node pools?
+* Do we want to enable auto-repair always on node pools?

--- a/node_pool_taint/README.post_tf_inputs.md
+++ b/node_pool_taint/README.post_tf_inputs.md
@@ -1,0 +1,7 @@
+## Future To-do Items
+
+* Perform additional testing  of conditions that will cause Terraform to recreate the node pool, based on the `keeper`s defined in the `random_id` resource.
+* Determine whether, depending on results from the above testing, the node pool should have a `create_before_destroy` lifecycle.
+* Do we want to be able to enable auto-upgrade on node pools?
+* Do we want to be able to set taints on node pools?
+* Do we want to enable auto-repair always on node pools?

--- a/node_pool_taint/README.pre_tf_inputs.md
+++ b/node_pool_taint/README.pre_tf_inputs.md
@@ -1,0 +1,9 @@
+# Terraform GKE Node Pool Module
+
+This module manages a node pool attached to a Google Kubernetes Engine (GKE) cluster.
+
+## Using The Terraform Module
+
+This module requires version 2.0.0 or above of the Google Terraform provider.
+
+See the file [example-usage](./example-usage) for an example of how to use this module. Below are the available module inputs:

--- a/node_pool_taint/example-usage
+++ b/node_pool_taint/example-usage
@@ -1,0 +1,22 @@
+# In the below example, `module.customername_cluster` is an instance of
+# one of the GKE modules from this repository.
+
+module "customername_cluster_node_pool" {
+  source = "git@github.com:/FairwindsOps/terraform-gke//node_pool_taint"
+
+  name             = "node-pool-1"
+  region           = "${module.customername_cluster.region}"
+  gke_cluster_name = "${module.customername_cluster.name}"
+  machine_type     = "n1-standard-2"
+  min_node_count   = "1"
+  max_node_count   = "1"
+
+  taint = {
+    key    = "special"
+    value  = "true"
+    effect = "NO_SCHEDULE"
+  }
+
+  # Match the Kubernetes version from the GKE cluster!
+  kubernetes_version = "${module.customername_cluster.kubernetes_version}"
+}

--- a/node_pool_taint/inputs.tf
+++ b/node_pool_taint/inputs.tf
@@ -37,6 +37,11 @@ variable "node_labels" {
   default     = {}
 }
 
+variable "taint" {
+  description = "Add a taint to the nodes in the pool"
+  type        = "map"
+}
+
 variable "disk_type" {
   description = "Type of the disk attached to each node"
   default     = "pd-standard"

--- a/node_pool_taint/main.tf
+++ b/node_pool_taint/main.tf
@@ -24,6 +24,7 @@ resource "random_id" "entropy" {
 }
 
 resource "google_container_node_pool" "node_pool" {
+  provider           = "google-beta"
   name               = "${var.name}-${random_id.entropy.hex}"
   cluster            = "${var.gke_cluster_name}"
   location           = "${var.region}"
@@ -40,6 +41,7 @@ resource "google_container_node_pool" "node_pool" {
     disk_size_gb = "${var.disk_size_in_gb}"
     machine_type = "${var.machine_type}"
     labels       = "${var.node_labels}"
+    taint        = ["${var.taint}"]
     disk_type    = "${var.disk_type}"
 
     oauth_scopes = [

--- a/node_pool_taint/main.tf
+++ b/node_pool_taint/main.tf
@@ -18,6 +18,9 @@ resource "random_id" "entropy" {
     name         = "${var.name}"
     region       = "${var.region}"
     disk_size    = "${var.disk_size_in_gb}"
+    disk_type    = "${var.disk_type}"
+    labels       = "${jsonencode(var.node_labels)}"
+    taint        = "${jsonencode(var.taint)}"
   }
 
   byte_length = 2

--- a/node_pool_taint/outputs.tf
+++ b/node_pool_taint/outputs.tf
@@ -1,0 +1,2 @@
+# No known outputs needed
+


### PR DESCRIPTION
This adds the ability to add labels to nodes in a node pool. We can use this to assign pods to nodes in a pool by using nodeSelector and Affinity Features

Added support to set disk type. This will allow us to create nodes with SSD disks

Added support for taints which is in a separate module. Reason is that terraform 0.11 does not support dynamic blocks. When using the taint block the values are required which means we can't set that block as empty so all nodes will have to set a taint. The terraform taints feature is in beta and requires the google-beta provider.

Adding a label or a taint **will recreate the existing node pool**
Changing the disk type **will recreate the existing node pool**

Suggested tagging:
node-pool-v2.1.0
node-pool-taint-v2.1.0

