### PR TITLE
add clouddns auth to base oauth scope

### DIFF
--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -34,6 +34,7 @@ locals {
     "https://www.googleapis.com/auth/logging.write",
     "https://www.googleapis.com/auth/monitoring",
     "https://www.googleapis.com/auth/compute",
+    "https://www.googleapis.com/auth/ndev.clouddns.readwrite",
   ]
 }
 


### PR DESCRIPTION
This auth scope is necessary for tools like external-dns to interact with Cloud DNS.