### PR TITLE
Add option to enable workload identity on cluster

### DIFF
--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,3 +1,6 @@
+# node-pool-v3.3.0
+- Added `node_metadata` parameter to control node metadata provided to workload, so that [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) functionality may be used.
+
 # node-pool-v3.2.1
 - patch fix to generate a new random id when the additional_oauth_scopes var changes because that forces the node pool to be replaced
 

--- a/node_pool/README.md
+++ b/node_pool/README.md
@@ -96,6 +96,14 @@ Default:
 {}
 ```
 
+#### node\_metadata
+
+Description: Defines how to expose the node metadata to the workload running on the node. Acceptable options are `UNSPECIFIED`, `SECURE`, `EXPOSE`, and `GKE_METADATA_SERVER`. `GKE_METADATA_SERVER` will enable [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for the node pool. See the provider [docs here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#workload_metadata_config) for more details.
+
+Type: `string`
+
+Default: `UNSPECIFIED`
+
 #### node\_tags
 
 Description: List of strings for tags on node pool VMs. These are generally used for firewall rules.

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -74,3 +74,9 @@ variable "preemptible_nodes" {
   description = "Whether to use preemptible nodes"
   default     = false
 }
+
+variable "node_metadata" {
+  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA_SERVER` to enable workload identity"
+  default     = "UNSPECIFIED"
+  type        = string
+}

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -36,6 +36,10 @@ locals {
     "https://www.googleapis.com/auth/monitoring",
     "https://www.googleapis.com/auth/compute",
   ]
+
+  cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
+    node_metadata = var.node_metadata
+  }]
 }
 
 resource "google_container_node_pool" "node_pool" {
@@ -58,6 +62,13 @@ resource "google_container_node_pool" "node_pool" {
     disk_type    = var.disk_type
     tags         = var.node_tags
     preemptible  = var.preemptible_nodes
+
+    dynamic "workload_metadata_config" {
+      for_each = local.cluster_node_metadata_config
+      content {
+        node_metadata = workload_metadata_config.value.node_metadata
+      }
+    }
 
     oauth_scopes = concat(local.base_oauth_scope, var.additional_oauth_scopes)
   }

--- a/node_pool_taint/CHANGELOG.md
+++ b/node_pool_taint/CHANGELOG.md
@@ -1,3 +1,6 @@
+# node-pool-taint-v2.2.0
+- Added `node_metadata` parameter to control node metadata provided to workload, so that [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) functionality may be used.
+
 # node-pool-taint-v2.1.1
 - patch fix to generate a new random id when the additional_oauth_scopes var changes because that forces the node pool to be replaced
 

--- a/node_pool_taint/README.md
+++ b/node_pool_taint/README.md
@@ -102,6 +102,14 @@ Default:
 {}
 ```
 
+#### node\_metadata
+
+Description: Defines how to expose the node metadata to the workload running on the node. Acceptable options are `UNSPECIFIED`, `SECURE`, `EXPOSE`, and `GKE_METADATA_SERVER`. `GKE_METADATA_SERVER` will enable [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for the node pool. See the provider [docs here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#workload_metadata_config) for more details.
+
+Type: `string`
+
+Default: `UNSPECIFIED`
+
 #### node\_tags
 
 Description: List of strings for tags on node pool VMs. These are generally used for firewall rules.

--- a/node_pool_taint/inputs.tf
+++ b/node_pool_taint/inputs.tf
@@ -68,3 +68,9 @@ variable "preemptible_nodes" {
   description = "Whether to use preemptible nodes"
   default     = false
 }
+
+variable "node_metadata" {
+  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA_SERVER` to enable workload identity"
+  default     = "UNSPECIFIED"
+  type        = string
+}

--- a/node_pool_taint/main.tf
+++ b/node_pool_taint/main.tf
@@ -36,6 +36,10 @@ locals {
     "https://www.googleapis.com/auth/monitoring",
     "https://www.googleapis.com/auth/compute",
   ]
+
+  cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
+    node_metadata = var.node_metadata
+  }]
 }
 
 resource "google_container_node_pool" "node_pool" {
@@ -72,6 +76,13 @@ resource "google_container_node_pool" "node_pool" {
     disk_type   = var.disk_type
     tags        = var.node_tags
     preemptible = var.preemptible_nodes
+
+    dynamic "workload_metadata_config" {
+      for_each = local.cluster_node_metadata_config
+      content {
+        node_metadata = workload_metadata_config.value.node_metadata
+      }
+    }
 
     oauth_scopes = concat(local.base_oauth_scope, var.additional_oauth_scopes)
   }

--- a/vpc-native/README.md
+++ b/vpc-native/README.md
@@ -25,4 +25,5 @@ See the file [example-usage](./example-usage) for an example of how to use this 
 | `maintenance_policy_start_time`    | Maintenance Window (GMT)                            | `06:00`         |
 | `enable_private_endpoint`          | Private Kube API endpoint                           | `false`          |
 | `enable_private_nodes`             | Private compute instances                           | `false`          |
+| `enable_workload_identity`         | Enable workload identity for the cluster            | `false`         |
 | `master_ipv4_cidr_block`           | IPV4 CIDR block for controlplane (must be /28)      | `null`          |

--- a/vpc-native/inputs.tf
+++ b/vpc-native/inputs.tf
@@ -78,3 +78,9 @@ variable "vpa_enabled" {
   description = "A boolean to enable VPA for the cluster"
   default     = false
 }
+
+variable "workload_identity" {
+  type        = bool
+  description = "A boolean to enable workload identity"
+  default     = false
+}

--- a/vpc-native/inputs.tf
+++ b/vpc-native/inputs.tf
@@ -79,7 +79,7 @@ variable "vpa_enabled" {
   default     = false
 }
 
-variable "workload_identity" {
+variable "enable_workload_identity" {
   type        = bool
   description = "A boolean to enable workload identity"
   default     = false

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cluster_workload_identity_namespace = var.workload_identity ? ["${var.project}.svc.id.goog"] : []
+  cluster_workload_identity_namespace = var.enable_workload_identity ? ["${var.project}.svc.id.goog"] : []
 }
 
 resource "google_container_cluster" "cluster" {

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -1,3 +1,7 @@
+locals {
+  cluster_workload_identity_namespace = var.workload_identity ? ["${var.project}.svc.id.goog"] : []
+}
+
 resource "google_container_cluster" "cluster" {
   name               = var.name
   location           = var.region
@@ -40,6 +44,13 @@ resource "google_container_cluster" "cluster" {
   addons_config {
     network_policy_config {
       disabled = false
+    }
+  }
+
+  dynamic "workload_identity_config" {
+    for_each = local.cluster_workload_identity_namespace
+    content {
+      identity_namespace = local.cluster_workload_identity_namespace[0]
     }
   }
 


### PR DESCRIPTION
This PR adds an input variable to the cluster module that gives the ability to enable [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). I haven't had time to test if enabling this on an existing cluster is a breaking change, so I've set this new input variable to be false by default. 

When set to false, it creates no changes to the cluster. When set to true, this sets the identity namespace to `${var.project}.svc.id.goog`; that is to say, it sets the identity namespace to be scoped within the project the cluster was created in. [This is because the only identity namespace supported is the one that the cluster resides in.](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#workload_identity_config) 