### PR TITLE
Add ability to utilize confidential nodes in beta vpc-native module

### DIFF
--- a/vpc-native-beta/CHANGELOG.md
+++ b/vpc-native-beta/CHANGELOG.md
@@ -1,3 +1,8 @@
-## 1.4.1
+## vpc-native-beta-v1.4.3
+* Added var.enabled_confidential_nodes to allow deploying using confidential nodes
+## vpc-native-beta-v1.4.2
+* Added parameters for enabling GKE usage metering
+## vpc-native-beta-v1.4.1
+* Added the ability to use shielded nodes in a cluster
 ### Initial Release
 * GKE Module that supports private and public cluster settings with beta features using the `google-beta` provider.

--- a/vpc-native-beta/README.md
+++ b/vpc-native-beta/README.md
@@ -35,3 +35,4 @@ See the file [example-usage](./example-usage) for an example of how to use this 
 | `enable_node_local_dns_cache`      | A boolean to enable NodeLocal DNSCache              | `true`                                  |
 | `metering_bigquery_dataset`        | BigQuery dataset name to send GKE metering data to. Setting a value here implicitly enables GKE Usage Metering. | `""`    |
 | `enable_network_egress_metering`   | Boolean to turn on Network Egress Metering. Only useful if metering_bigquery_dataset variable is set.           | `false` |
+| `enabled_confidential_nodes`       | Boolean to turn on confidential nodes for the cluster.                              | `false` |

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -108,3 +108,9 @@ variable "enable_network_egress_metering" {
   description = "Boolean to turn on Network Egress Metering. Only useful if metering_bigquery_dataset variable is set."
   default     = false
 }
+
+variable "enabled_confidential_nodes" {
+  type = bool
+  description = "Boolean to turn on confidential nodes for the cluster."
+  default = false
+}

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -32,7 +32,7 @@ variable "services_secondary_ip_range_name" {
 }
 
 variable "master_authorized_network_cidrs" {
-  type        = list
+  type        = list(any)
   description = "A list of up to 20 maps containing `master_authorized_network_cidrs` and `display_name` keys, representing source network CIDRs that are allowed to connect master nodes over HTTPS."
 
   default = [
@@ -110,7 +110,7 @@ variable "enable_network_egress_metering" {
 }
 
 variable "enabled_confidential_nodes" {
-  type = bool
+  type        = bool
   description = "Boolean to turn on confidential nodes for the cluster."
-  default = false
+  default     = false
 }

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -1,6 +1,7 @@
 locals {
   cluster_workload_identity_namespace = var.enable_workload_identity ? ["${var.project}.svc.id.goog"] : []
   metering_bigquery_dataset           = length(var.metering_bigquery_dataset) > 0 ? [var.metering_bigquery_dataset] : []
+  confidential_nodes_enabled          = var.enabled_confidential_nodes ? ["1"] : []
 }
 
 resource "google_container_cluster" "cluster" {
@@ -67,6 +68,13 @@ resource "google_container_cluster" "cluster" {
       bigquery_destination {
         dataset_id = var.metering_bigquery_dataset
       }
+    }
+  }
+
+  dynamic "confidential_nodes" {
+    for_each = local.confidential_nodes_enabled
+     content {
+      enabled = true
     }
   }
 

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -62,9 +62,9 @@ resource "google_container_cluster" "cluster" {
   }
 
   dynamic "resource_usage_export_config" {
-    for_each                             = local.metering_bigquery_dataset
+    for_each = local.metering_bigquery_dataset
     content {
-      enable_network_egress_metering       = var.enable_network_egress_metering
+      enable_network_egress_metering = var.enable_network_egress_metering
       bigquery_destination {
         dataset_id = var.metering_bigquery_dataset
       }
@@ -73,7 +73,7 @@ resource "google_container_cluster" "cluster" {
 
   dynamic "confidential_nodes" {
     for_each = local.confidential_nodes_enabled
-     content {
+    content {
       enabled = true
     }
   }

--- a/vpc-native/CHANGELOG.md
+++ b/vpc-native/CHANGELOG.md
@@ -1,3 +1,5 @@
+## vpc-native-v1.4.2
+* Added parameters for enabling GKE usage metering
 ## vpc-native-v1.4.1
 * Added the ability to use shielded nodes in a cluster
 ## 1.0.0


### PR DESCRIPTION
I did this with a `dynamic` block because even if this is added in to an existing cluster with a value of `false` it will want to recreate the entire cluster. This will work around that issue.