### PR TITLE
update config for compatibility with 4.x gcp provider

### DIFF
--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,3 +1,6 @@
+# node-pool-v3.6.0
+- Prepares module for compatibility with future 4.x GCP provider
+
 # node-pool-v3.5.0
 - Fixed taints so that Terraform won't error out if you don't specify them on a node pool
 

--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,5 +1,6 @@
 # node-pool-v3.6.0
 - Prepares module for compatibility with future 4.x GCP provider
+- Added image_type parameter to control the OS image of the node pool
 
 # node-pool-v3.5.0
 - Fixed taints so that Terraform won't error out if you don't specify them on a node pool

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -76,7 +76,7 @@ variable "preemptible_nodes" {
 }
 
 variable "node_metadata" {
-  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA_SERVER` to enable workload identity"
+  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA` to enable workload identity"
   default     = "UNSPECIFIED"
   type        = string
 }

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -70,7 +70,7 @@ resource "google_container_node_pool" "node_pool" {
     dynamic "workload_metadata_config" {
       for_each = local.cluster_node_metadata_config
       content {
-        node_metadata = workload_metadata_config.value.node_metadata
+        mode = workload_metadata_config.value.node_metadata
       }
     }
 

--- a/node_pool/versions.tf
+++ b/node_pool/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = ">=2.5.0"
+    google = ">=4.0.0"
   }
 }

--- a/node_pool/versions.tf
+++ b/node_pool/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = ">=4.0.0"
+    google = ">=3.90.0"
   }
 }

--- a/node_pool_taint/CHANGELOG.md
+++ b/node_pool_taint/CHANGELOG.md
@@ -1,3 +1,6 @@
+# node-pool-taint-v2.3.0
+- Prepares module for compatibility with future 4.x GCP provider
+
 # node-pool-taint-v2.2.0
 - Added `node_metadata` parameter to control node metadata provided to workload, so that [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) functionality may be used.
 

--- a/node_pool_taint/CHANGELOG.md
+++ b/node_pool_taint/CHANGELOG.md
@@ -1,5 +1,6 @@
 # node-pool-taint-v2.3.0
 - Prepares module for compatibility with future 4.x GCP provider
+- Added image_type parameter to control the OS image of the node pool
 
 # node-pool-taint-v2.2.0
 - Added `node_metadata` parameter to control node metadata provided to workload, so that [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) functionality may be used.

--- a/node_pool_taint/inputs.tf
+++ b/node_pool_taint/inputs.tf
@@ -70,7 +70,7 @@ variable "preemptible_nodes" {
 }
 
 variable "node_metadata" {
-  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA_SERVER` to enable workload identity"
+  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA` to enable workload identity"
   default     = "UNSPECIFIED"
   type        = string
 }

--- a/node_pool_taint/main.tf
+++ b/node_pool_taint/main.tf
@@ -80,7 +80,7 @@ resource "google_container_node_pool" "node_pool" {
     dynamic "workload_metadata_config" {
       for_each = local.cluster_node_metadata_config
       content {
-        node_metadata = workload_metadata_config.value.node_metadata
+        mode = workload_metadata_config.value.node_metadata
       }
     }
 

--- a/node_pool_taint/versions.tf
+++ b/node_pool_taint/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google-beta = ">=2.5.0"
+    google-beta = ">=4.0.0"
   }
 }

--- a/node_pool_taint/versions.tf
+++ b/node_pool_taint/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google-beta = ">=4.0.0"
+    google-beta = ">=3.90.0"
   }
 }

--- a/vpc-native-beta/CHANGELOG.md
+++ b/vpc-native-beta/CHANGELOG.md
@@ -1,3 +1,5 @@
+## vpc-native-beta-v1.5.0
+* Prepares module for compatibility with future 4.x GCP provider
 ## vpc-native-beta-v1.4.5
 * The initial node_pool needs to have a n2d machine type if confidential nodes are enabled
 ## vpc-native-beta-v1.4.4

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -31,9 +31,6 @@ resource "google_container_cluster" "cluster" {
 
   # The absence of a user and password here disables basic auth
   master_auth {
-    username = ""
-    password = ""
-
     client_certificate_config {
       issue_client_certificate = false
     }
@@ -57,7 +54,7 @@ resource "google_container_cluster" "cluster" {
   dynamic "workload_identity_config" {
     for_each = local.cluster_workload_identity_namespace
     content {
-      identity_namespace = local.cluster_workload_identity_namespace[0]
+      workload_pool = local.cluster_workload_identity_namespace[0]
     }
   }
 

--- a/vpc-native-beta/versions.tf
+++ b/vpc-native-beta/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google-beta = ">=2.5.0"
+    google-beta = ">=4.0.0"
   }
 }

--- a/vpc-native-beta/versions.tf
+++ b/vpc-native-beta/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google-beta = ">=4.0.0"
+    google-beta = ">=3.90.0"
   }
 }

--- a/vpc-native/CHANGELOG.md
+++ b/vpc-native/CHANGELOG.md
@@ -1,3 +1,5 @@
+## vpc-native-v1.5.0
+* Prepares module for compatibility with future 4.x GCP provider
 ## vpc-native-v1.4.2
 * Added parameters for enabling GKE usage metering
 ## vpc-native-v1.4.1

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -29,8 +29,6 @@ resource "google_container_cluster" "cluster" {
 
   # The absence of a user and password here disables basic auth
   master_auth {
-    username = ""
-    password = ""
 
     client_certificate_config {
       issue_client_certificate = false
@@ -52,7 +50,7 @@ resource "google_container_cluster" "cluster" {
   dynamic "workload_identity_config" {
     for_each = local.cluster_workload_identity_namespace
     content {
-      identity_namespace = local.cluster_workload_identity_namespace[0]
+      workload_pool = local.cluster_workload_identity_namespace[0]
     }
   }
 

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -29,7 +29,6 @@ resource "google_container_cluster" "cluster" {
 
   # The absence of a user and password here disables basic auth
   master_auth {
-
     client_certificate_config {
       issue_client_certificate = false
     }

--- a/vpc-native/versions.tf
+++ b/vpc-native/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = ">=2.5.0"
+    google = ">=4.0.0"
   }
 }

--- a/vpc-native/versions.tf
+++ b/vpc-native/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = ">=4.0.0"
+    google = ">=3.90.0"
   }
 }


### PR DESCRIPTION
Couple minor tweaks necessary for compatibility with the newer 4.x gcp provider version. `username` and `password` were removed entirely from the `master_auth` config block of `google_container_cluster`; otherwise a couple workload identity bits changed for the node pool config. Note that `GKE_METADATA_SERVER` has to be input as `GKE_METADATA` now. 

I tested updating the `vpc-native` and `node_pool` modules on an existing cluster and it seemed to work fine -- terraform reported no changes were necessary.