### PR TITLE
Ignore changes to cluster resource labels

### DIFF
--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -120,3 +120,7 @@ variable "confidential_nodes_initial_machine_type" {
   description = "Initial node_pool that is removed should get an n2d machine type even though it will get removed after creation."
   default     = "n2d-standard-2"
 }
+
+variable "resource_labels" {
+  description = "Custom resource labels to add to the cluster configuration."
+}

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -120,7 +120,3 @@ variable "confidential_nodes_initial_machine_type" {
   description = "Initial node_pool that is removed should get an n2d machine type even though it will get removed after creation."
   default     = "n2d-standard-2"
 }
-
-variable "resource_labels" {
-  description = "Custom resource labels to add to the cluster configuration."
-}

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -112,7 +112,7 @@ resource "google_container_cluster" "cluster" {
 
   resource_labels = {
     kubernetescluster = var.name,
-    var.resource_labels ? resource_labels : ""
+    var.resource_labels ? var.resource_labels : ""
   }
 
   lifecycle {

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -109,7 +109,6 @@ resource "google_container_cluster" "cluster" {
 
   resource_labels = {
     kubernetescluster = var.name,
-    var.resource_labels ? var.resource_labels : ""
   }
 
   lifecycle {
@@ -123,6 +122,7 @@ resource "google_container_cluster" "cluster" {
       node_config,
       network,
       subnetwork,
+      resource_labels,
     ]
   }
 }

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -111,7 +111,8 @@ resource "google_container_cluster" "cluster" {
   }
 
   resource_labels = {
-    kubernetescluster = var.name
+    kubernetescluster = var.name,
+    var.resource_labels ? resource_labels : ""
   }
 
   lifecycle {
@@ -128,4 +129,3 @@ resource "google_container_cluster" "cluster" {
     ]
   }
 }
-

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -103,7 +103,7 @@ resource "google_container_cluster" "cluster" {
       node_pool,
       network,
       subnetwork,
-      resource_labels
+      resource_labels,
     ]
   }
 }

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -94,7 +94,7 @@ resource "google_container_cluster" "cluster" {
 
   resource_labels = {
     kubernetescluster = var.name,
-    var.resource_labels ? var.resource_labels : ""
+    length(var.resource_labels) > 0 ? var.resource_labels : ""
   }
 
   lifecycle {

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -93,7 +93,8 @@ resource "google_container_cluster" "cluster" {
   }
 
   resource_labels = {
-    kubernetescluster = var.name
+    kubernetescluster = var.name,
+    var.resource_labels ? var.resource_labels : ""
   }
 
   lifecycle {
@@ -109,4 +110,3 @@ resource "google_container_cluster" "cluster" {
     ]
   }
 }
-

--- a/vpc-native/main.tf
+++ b/vpc-native/main.tf
@@ -93,8 +93,7 @@ resource "google_container_cluster" "cluster" {
   }
 
   resource_labels = {
-    kubernetescluster = var.name,
-    length(var.resource_labels) > 0 ? var.resource_labels : ""
+    kubernetescluster = var.name
   }
 
   lifecycle {
@@ -107,6 +106,7 @@ resource "google_container_cluster" "cluster" {
       node_pool,
       network,
       subnetwork,
+      resource_labels
     ]
   }
 }


### PR DESCRIPTION
As per conversation with Andy, we can ignore this since GKE just adds and removes the `goog-gameservices` label at will, apparently.

As you can see from the commit history, I tried to make it configurable, but I'm not sure how to do that when extra labels may or may not be provided by the user _and_ we have an existing one on all clusters that we definitely want to keep.