### PR TITLE
Add node pool spot bool

### DIFF
--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,3 +1,6 @@
+# node-pool-v3.7.0
+- Added the ability to use spot vms on a node pool. This can be enabled by setting the variable `spot_nodes` to true. This can only be enabled on new node pools and cannot be toggled after creation. Can only be used with GKE 1.22+.
+
 # node-pool-v3.6.0
 - Prepares module for compatibility with future 4.x GCP provider
 - Added image_type parameter to control the OS image of the node pool

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -80,6 +80,11 @@ variable "preemptible_nodes" {
   default     = false
 }
 
+variable "spot_nodes"{
+  description = "Whether to use spot nodes"
+  default     = false
+}
+
 variable "node_metadata" {
   description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA` to enable workload identity"
   default     = "UNSPECIFIED"

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -63,6 +63,7 @@ resource "google_container_node_pool" "node_pool" {
     disk_type    = var.disk_type
     tags         = var.node_tags
     preemptible  = var.preemptible_nodes
+    spot         = var.spot_nodes
     shielded_instance_config {
       enable_secure_boot = var.enable_secure_boot
     }


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
This PR allows setting a node pool to use spot vm's in GKE 1.22 and up. 

### What changes did you make?
Added `spot_nodes` boolean that defaults to false. 

### What alternative solution should we consider, if any?

