### PR TITLE
[WIP] Add initial node count, node metadata and min cpu platform to ignore_changes block

### DIFF
--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,3 +1,6 @@
+# node-pool-v3.8.0
+- Added the following values to ignore_changes on the node pool, since they aren't commonly configured but instead set by GKE: `initial_node_count`, `node_config.0.metadata` and `node_config.0.min_cpu_platform`
+
 # node-pool-v3.7.0
 - Added the ability to use spot vms on a node pool. This can be enabled by setting the variable `spot_nodes` to true. This can only be enabled on new node pools and cannot be toggled after creation. Can only be used with GKE 1.22+.
 

--- a/node_pool/README.md
+++ b/node_pool/README.md
@@ -152,10 +152,38 @@ Type: `bool`
 
 Default: `false`
 
-## Future To-do Items
+#### image_type
 
-* Perform additional testing  of conditions that will cause Terraform to recreate the node pool, based on the `keeper`s defined in the `random_id` resource.
-* Determine whether, depending on results from the above testing, the node pool should have a `create_before_destroy` lifecycle.
+Description: The OS image to be used for the nodes.
+
+Type: `string`
+
+Default: none
+
+#### spot_nodes
+
+Description: Whether to use spot nodes in this pool.
+
+Type: `bool`
+
+Default: `false`
+
+#### enable_secure_boot
+
+Description: If shielded nodes is enabled at the cluster level, you can optionally set this to enable secure boot on shielded nodes.
+
+Type: `bool`
+
+Default: `false`
+
+#### taint
+
+Description: Dictionary of effect, key and value to apply on nodes in pool. Only one is allowed.
+
+Type: `map`
+
+Default: `null`
+
+## Future To-do Items
 * Do we want to be able to enable auto-upgrade on node pools?
-* Do we want to be able to set taints on node pools?
 * Do we want to enable auto-repair always on node pools?

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -1,40 +1,25 @@
-variable "name" {
-  description = "The name of the node pool. A random string will be appended to this name, to allow replacement node pools to be created before destroying the current pool."
-}
-
 variable "gke_cluster_name" {
   description = "The name of the GKE cluster to bind this node pool."
-}
-
-variable "region" {
-  description = "The region for the node pool."
-}
-
-variable "initial_node_count" {
-  description = "The initial node count for the pool, per availability zone. Changing this will force recreation of the resource."
-  default     = "1"
-}
-
-variable "min_node_count" {
-  description = "Minimum number of nodes for autoscaling, per availability zone."
-}
-
-variable "max_node_count" {
-  description = "Maximum number of nodes for autoscaling, per availability zone."
 }
 
 variable "kubernetes_version" {
   description = "The kubernetes version for the nodes in the pool. This should match the Kubernetes version of the GKE cluster."
 }
 
-variable "image_type" {
-  description = "The OS image to be used for the nodes."
-  default     = "COS"
+variable "max_node_count" {
+  description = "Maximum number of nodes for autoscaling, per availability zone."
 }
 
-variable "machine_type" {
-  description = "The machine type of nodes in the pool."
-  default     = "n1-standard-4"
+variable "min_node_count" {
+  description = "Minimum number of nodes for autoscaling, per availability zone."
+}
+
+variable "name" {
+  description = "The name of the node pool. A random string will be appended to this name, to allow replacement node pools to be created before destroying the current pool."
+}
+
+variable "region" {
+  description = "The region for the node pool."
 }
 
 variable "disk_size_in_gb" {
@@ -42,10 +27,19 @@ variable "disk_size_in_gb" {
   default     = "100"
 }
 
-variable "node_tags" {
-  type        = list
-  description = "List of strings for tags on node pool VMs. These are generally used for firewall rules."
-  default     = []
+variable "disk_type" {
+  description = "Type of the disk attached to each node"
+  default     = "pd-standard"
+}
+
+variable "initial_node_count" {
+  description = "The initial node count for the pool, per availability zone. Changing this will force recreation of the resource."
+  default     = "1"
+}
+
+variable "machine_type" {
+  description = "The machine type of nodes in the pool."
+  default     = "n1-standard-4"
 }
 
 variable "node_labels" {
@@ -54,9 +48,16 @@ variable "node_labels" {
   default     = {}
 }
 
-variable "disk_type" {
-  description = "Type of the disk attached to each node"
-  default     = "pd-standard"
+variable "node_metadata" {
+  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA` to enable workload identity"
+  default     = "UNSPECIFIED"
+  type        = string
+}
+
+variable "node_tags" {
+  type        = list
+  description = "List of strings for tags on node pool VMs. These are generally used for firewall rules."
+  default     = []
 }
 
 variable "additional_oauth_scopes" {
@@ -80,15 +81,15 @@ variable "preemptible_nodes" {
   default     = false
 }
 
-variable "spot_nodes"{
-  description = "Whether to use spot nodes"
-  default     = false
+variable "image_type" {
+  description = "The OS image to be used for the nodes."
+  default     = "COS"
 }
 
-variable "node_metadata" {
-  description = "Specifies how node metadata is exposed to the workload running on the node. Set to `GKE_METADATA` to enable workload identity"
-  default     = "UNSPECIFIED"
-  type        = string
+variable "spot_nodes"{
+  type        = bool
+  description = "Whether to use spot nodes"
+  default     = false
 }
 
 variable "enable_secure_boot" {

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -98,7 +98,7 @@ variable "enable_secure_boot" {
 }
 
 variable "taint" {
-  description = "Key value pairs of taints to apply on nodes in the pool"
+  description = "Dictionary of effect, key and value to apply on nodes in pool"
   type        = map
   default     = null
 }

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -33,7 +33,7 @@ variable "disk_type" {
 }
 
 variable "initial_node_count" {
-  description = "The initial node count for the pool, per availability zone. Changing this will force recreation of the resource."
+  description = "The initial node count for the pool, per availability zone. This has been ignored on the node pool module resource. Remove it from ignore_changes if you want to set it yourself, but 1 is usually sufficient."
   default     = "1"
 }
 

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -99,5 +99,10 @@ resource "google_container_node_pool" "node_pool" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      initial_node_count,
+      node_config.0.metadata,
+      node_config.0.min_cpu_platform
+    ]
   }
 }


### PR DESCRIPTION
## Checklist
* [ x ] I have signed the CLA
* [ x ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

To make sure that Terraform does not try to destroy and recreate node pools with changes to values that aren't commonly custom-configured, usually won't change, or are set by GKE themselves.

### What changes did you make?

I added the following values to the ignore_changes block on the node pool module:

```
initial_node_count
node_config.0.metadata
node_config.0.min_cpu_platform
```

### What alternative solution should we consider, if any?

We could make all of these configurable instead, but as far as I'm aware we haven't ever touched them in practice after the initial creation of the node pools.