### PR TITLE
Add ignore_changes lifecycle update

### DIFF
--- a/node_pool_taint/main.tf
+++ b/node_pool_taint/main.tf
@@ -89,6 +89,11 @@ resource "google_container_node_pool" "node_pool" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      initial_node_count,
+      node_config.0.metadata,
+      node_config.0.min_cpu_platform
+    ]
   }
 }
 


### PR DESCRIPTION
Makes the node_pool_taint module match the node_pool 3.8.0 module.
Adds the same lifecycle ignore block to prevent changes in `initial_node_count`, `node_config.0.metadata`, and `node_config.0.min_cpu_platform` from recreating nodepools.


This PR fixes #

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

