### PR TITLE
Test tf timeout

### DIFF
--- a/node_pool/CHANGELOG.md
+++ b/node_pool/CHANGELOG.md
@@ -1,3 +1,6 @@
+# node-pool-v3.8.2
+- Added `timeout_create`, `timeout_delete`, and `timeout_update` parameters to provide a way to override the Terraform default timeouts for these actions on `google_container_node_pool` node pool resource.
+
 # node-pool-v3.8.1
 - Added `node_locations` parameter to limit a node pool to specific zones. Zones selected must be in the parent clusters region. If left empty nodes will default to their parent clusters zones. **Note: node_locations will not revert to the cluster's default set of zones upon being unset. You must manually reconcile the list of zones with your cluster.
 

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -109,3 +109,21 @@ variable "taint" {
   type        = map
   default     = null
 }
+
+variable "timeout_create"{
+  type        = string
+  description = "Override default timeout for CRUD function"
+  default     = "30m"
+}
+
+variable "timeout_delete"{
+  type        = string
+  description = "Override default timeout for CRUD function"
+  default     = "30m"
+}
+
+variable "timeout_update"{
+  type        = string
+  description = "Override default timeout for CRUD function"
+  default     = "30m"
+}

--- a/node_pool/inputs.tf
+++ b/node_pool/inputs.tf
@@ -112,18 +112,18 @@ variable "taint" {
 
 variable "timeout_create"{
   type        = string
-  description = "Override default timeout for CRUD function"
+  description = "Override default timeout for CREATE function"
   default     = "30m"
 }
 
 variable "timeout_delete"{
   type        = string
-  description = "Override default timeout for CRUD function"
+  description = "Override default timeout for DELETE function"
   default     = "30m"
 }
 
 variable "timeout_update"{
   type        = string
-  description = "Override default timeout for CRUD function"
+  description = "Override default timeout for UPDATE function"
   default     = "30m"
 }

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -108,7 +108,8 @@ resource "google_container_node_pool" "node_pool" {
   }
 
   timeouts {
-    create = "10s"
-    update = "1m"
+    create = "1m"
+    update = var.timeout_update
+    delete = var.timeout_delete
   }
 }

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -107,7 +107,7 @@ resource "google_container_node_pool" "node_pool" {
     ]
   }
 
-  timeouts {
+  atimeouts {
     dudecreate = "1m"
     update = var.timeout_update
     delete = var.timeout_delete

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -107,8 +107,8 @@ resource "google_container_node_pool" "node_pool" {
     ]
   }
 
-  atimeouts {
-    dudecreate = "1m"
+  timeouts {
+    create = var.timeout_create
     update = var.timeout_update
     delete = var.timeout_delete
   }

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -106,4 +106,9 @@ resource "google_container_node_pool" "node_pool" {
       node_config.0.min_cpu_platform
     ]
   }
+
+  timeouts {
+    create = "10s"
+    update = "1m"
+  }
 }

--- a/node_pool/main.tf
+++ b/node_pool/main.tf
@@ -108,7 +108,7 @@ resource "google_container_node_pool" "node_pool" {
   }
 
   timeouts {
-    create = "1m"
+    dudecreate = "1m"
     update = var.timeout_update
     delete = var.timeout_delete
   }


### PR DESCRIPTION
This PR fixes #

## Checklist
* [ x] I have signed the CLA
* [ x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To add a way to override Terraform default timeouts for node pool resource.

### What changes did you make?
Added a timeout for create, update, delete on the google_container_node_pool resource

### What alternative solution should we consider, if any?
This is making this module more extensible by adding timeouts to the google_container_node_pool resource