### PR TITLE
Added monitoring config block into the cluster resource

### DIFF
--- a/vpc-native-beta/CHANGELOG.md
+++ b/vpc-native-beta/CHANGELOG.md
@@ -1,3 +1,5 @@
+## vpc-native-beta-v1.5.1
+* Enables utilizing GCP managed prometheus
 ## vpc-native-beta-v1.5.0
 * Prepares module for compatibility with future 4.x GCP provider
 ## vpc-native-beta-v1.4.5

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -120,3 +120,8 @@ variable "confidential_nodes_initial_machine_type" {
   description = "Initial node_pool that is removed should get an n2d machine type even though it will get removed after creation."
   default     = "n2d-standard-2"
 }
+variable "enable_managed_prometheus" {
+  type        = bool
+  description = "Boolean to enable Google Managed Prometheus on clusters"
+  default     = false
+}

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -36,6 +36,11 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
+  monitoring_config {
+    managed_prometheus {
+      enabled = var.enable_managed_prometheus
+    }
+  }
   private_cluster_config {
     enable_private_endpoint = var.enable_private_endpoint
     enable_private_nodes    = var.enable_private_nodes


### PR DESCRIPTION
This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow users to use managed prometheus in GKE Clusters by adding in the monitoring config block for the vpc-native-beta module. 
### What changes did you make?

### What alternative solution should we consider, if any?

