### PR TITLE
Add support for monitoring prometheus

### DIFF
--- a/vpc-native-beta/CHANGELOG.md
+++ b/vpc-native-beta/CHANGELOG.md
@@ -1,14 +1,31 @@
+## vpc-native-beta-v1.5.1
+
+- Enables utilizing GCP managed prometheus
+
 ## vpc-native-beta-v1.5.0
-* Prepares module for compatibility with future 4.x GCP provider
+
+- Prepares module for compatibility with future 4.x GCP provider
+
 ## vpc-native-beta-v1.4.5
-* The initial node_pool needs to have a n2d machine type if confidential nodes are enabled
+
+- The initial node_pool needs to have a n2d machine type if confidential nodes are enabled
+
 ## vpc-native-beta-v1.4.4
-* Fix typo var name var.enabled_confidential_nodes -> var.enable_confidential_nodes
+
+- Fix typo var name var.enabled_confidential_nodes -> var.enable_confidential_nodes
+
 ## vpc-native-beta-v1.4.3
-* Added var.enabled_confidential_nodes to allow deploying using confidential nodes
+
+- Added var.enabled_confidential_nodes to allow deploying using confidential nodes
+
 ## vpc-native-beta-v1.4.2
-* Added parameters for enabling GKE usage metering
+
+- Added parameters for enabling GKE usage metering
+
 ## vpc-native-beta-v1.4.1
-* Added the ability to use shielded nodes in a cluster
+
+- Added the ability to use shielded nodes in a cluster
+
 ### Initial Release
-* GKE Module that supports private and public cluster settings with beta features using the `google-beta` provider.
+
+- GKE Module that supports private and public cluster settings with beta features using the `google-beta` provider.

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -120,3 +120,8 @@ variable "confidential_nodes_initial_machine_type" {
   description = "Initial node_pool that is removed should get an n2d machine type even though it will get removed after creation."
   default     = "n2d-standard-2"
 }
+variable "enable_managed_prometheus" {
+  type        = bool
+  description = "Boolean to enable Google Managed Prometheus on clusters"
+  default     = false
+}

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -35,7 +35,11 @@ resource "google_container_cluster" "cluster" {
       issue_client_certificate = false
     }
   }
-
+  monitoring_config {
+    managed_prometheus {
+      enabled = var.enable_managed_prometheus
+    }
+  }
   private_cluster_config {
     enable_private_endpoint = var.enable_private_endpoint
     enable_private_nodes    = var.enable_private_nodes


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow users to use managed prometheus in GKE Clusters by adding in the monitoring config block for the vpc-native-beta module.

### What changes did you make?

### What alternative solution should we consider, if any?

