### PR TITLE
Enable GKE Cost allocation in the vpc-native-beta module

### DIFF
--- a/vpc-native-beta/CHANGELOG.md
+++ b/vpc-native-beta/CHANGELOG.md
@@ -1,3 +1,7 @@
+## vpc-native-beta-v1.5.2
+
+- Enables GCP cost allocation for clusters
+
 ## vpc-native-beta-v1.5.1
 
 - Enables utilizing GCP managed prometheus

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -125,3 +125,8 @@ variable "enable_managed_prometheus" {
   description = "Boolean to enable Google Managed Prometheus on clusters"
   default     = false
 }
+variable "enable_cost_allocation" {
+  type        = bool
+  description = "Boolean to enable Google Managed Prometheus on clusters"
+  default     = false
+}

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -127,6 +127,6 @@ variable "enable_managed_prometheus" {
 }
 variable "enable_cost_allocation" {
   type        = bool
-  description = "Boolean to enable Google Managed Prometheus on clusters"
+  description = "Boolean to enable GKE Cost Allocation"
   default     = false
 }

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -45,7 +45,9 @@ resource "google_container_cluster" "cluster" {
     enable_private_nodes    = var.enable_private_nodes
     master_ipv4_cidr_block  = var.master_ipv4_cidr_block
   }
-
+  cost_management_config {
+    enabled = var.enable_cost_allocation
+  }
   addons_config {
     network_policy_config {
       disabled = false


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Enable cost allocation in the vpc-native-beta module.
### What changes did you make?
Added cost management block into cluster config.
### What alternative solution should we consider, if any?
N/A

