### PR TITLE
logging and monitoring config changes

### DIFF
--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -27,6 +27,11 @@ variable "pods_secondary_ip_range_name" {
   description = "The name of an existing network secondary IP range to be used for pods."
 }
 
+variable "release_channel" {
+  description = "The release channel for the Kubernetes version."
+  default = "UNSPECIFIED"
+}
+
 variable "services_secondary_ip_range_name" {
   description = "The name of an existing network secondary IP range to be used for services."
 }
@@ -64,14 +69,14 @@ variable "master_ipv4_cidr_block" {
   default     = null
 }
 
-variable "monitoring_service" {
-  description = "The monitoring service to write metrics to"
-  default     = "monitoring.googleapis.com/kubernetes"
+variable "monitoring_config" {
+  description = "Exposes metrics cluster components."
+  default     = [ "SYSTEM_COMPONENTS" ]
 }
 
-variable "logging_service" {
-  description = "The logging service to write logs to"
-  default     = "logging.googleapis.com/kubernetes"
+variable "logging_config" {
+  description = "Exposes logs for cluster components."
+  default     = [ "SYSTEM_COMPONENTS" ]
 }
 
 variable "vpa_enabled" {

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -11,8 +11,6 @@ resource "google_container_cluster" "cluster" {
   min_master_version    = var.kubernetes_version
   network               = var.network_name
   subnetwork            = var.nodes_subnetwork_name
-  monitoring_service    = var.monitoring_service
-  logging_service       = var.logging_service
   enable_shielded_nodes = var.enable_shielded_nodes
 
 
@@ -35,7 +33,16 @@ resource "google_container_cluster" "cluster" {
       issue_client_certificate = false
     }
   }
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  logging_config {
+    enable_components = var.logging_config
+  }
   monitoring_config {
+    enable_components = var.monitoring_config
     managed_prometheus {
       enabled = var.enable_managed_prometheus
     }


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

One part of the PR adjusts how logging and monitoring for the cluster is configured, based on this error when creating a cluster using the beta provider:

```
│ Error: googleapi: Error 400: Cannot specify logging_config or monitoring_config together with logging_service or monitoring_service.
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.RequestInfo",
│     "requestId": "0xeb04bf4e4682d246"
│   }
│ ]
│ , badRequest
│
│   with module.cluster_upgrade_test_1.google_container_cluster.cluster,
│   on .terraform/modules/cluster_upgrade_test_1/vpc-native-beta/main.tf line 7, in resource "google_container_cluster" "cluster":
│    7: resource "google_container_cluster" "cluster" {
```

It appears that this is due to changes in the Google API as mentioned in the following issues. `logging_service` and `monitoring_service` are being deprecated, and `logging_config` and `monitoring_config` can be used to create the same settings.

https://github.com/hashicorp/terraform-provider-google/issues/10820
https://github.com/hashicorp/terraform-provider-google/issues/13861

The other part reflects that, if a release channel is not specified, Google will default to the `STANDARD` channel and require that `auto-upgrade` is set to `true`.

### What changes did you make?

We have removed the `logging_service_enabled` and `monitoring_service_enabled` parameters, and replaced them with `logging_config` and `monitoring_config` parameters.

We also set a `release_channel` parameter that defaults to `UNSPECIFIED`. This allows us to both specify the GKE version, and keeps Google from auto-upgrading the cluster.

### What alternative solution should we consider, if any?

