### PR TITLE
feat: allow module to use legacy logging options, define maintenance windows and allow intranode visibility

### DIFF
--- a/vpc-native-beta/CHANGELOG.md
+++ b/vpc-native-beta/CHANGELOG.md
@@ -1,3 +1,13 @@
+## vpc-native-beta-v1.7.0
+
+- Enables Intranode Visibility Customization
+- Adds 9am-5pm Monday-Friday maintenance window
+- Allows using legacy logging and monitoring service variables
+
+## vpc-native-beta-v1.6.0
+
+- Enables logging and monitoring config values in module
+
 ## vpc-native-beta-v1.5.2
 
 - Enables GCP cost allocation for clusters

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -49,22 +49,18 @@ variable "master_authorized_network_cidrs" {
   ]
 }
 
-variable "maintenance_policy_start_time" {
+
+variable "maintenance_policy_window_start_time" {
   description = "The time (in GMT) when the cluster maintenance window will start."
-  type = string
-  default = ""
-}
-variable "maintenance_policy_recurring_window_end_time" {
-  description = "The time (in GMT) when the cluster maintenance window will start."
-  default = "1970-01-01T19:00:00Z"
+  default = "1970-01-01T13:00:00Z"
   type = string
 }
-variable "maintenance_policy_recurring_window_start_time" {
+variable "maintenance_policy_window_end_time" {
   description = "The time (in GMT) when the cluster maintenance window will start."
-  default = "1970-01-01T15:00:00Z"
+  default = "1970-01-01T21:00:00Z"
   type = string
 }
-variable "maintenance_policy_recurring_window_recurrence" {
+variable "maintenance_policy_window_recurrence" {
   description = "The time (in GMT) when the cluster maintenance window will start."
   default = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
   type = string

--- a/vpc-native-beta/inputs.tf
+++ b/vpc-native-beta/inputs.tf
@@ -51,7 +51,23 @@ variable "master_authorized_network_cidrs" {
 
 variable "maintenance_policy_start_time" {
   description = "The time (in GMT) when the cluster maintenance window will start."
-  default     = "06:00"
+  type = string
+  default = ""
+}
+variable "maintenance_policy_recurring_window_end_time" {
+  description = "The time (in GMT) when the cluster maintenance window will start."
+  default = "1970-01-01T19:00:00Z"
+  type = string
+}
+variable "maintenance_policy_recurring_window_start_time" {
+  description = "The time (in GMT) when the cluster maintenance window will start."
+  default = "1970-01-01T15:00:00Z"
+  type = string
+}
+variable "maintenance_policy_recurring_window_recurrence" {
+  description = "The time (in GMT) when the cluster maintenance window will start."
+  default = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+  type = string
 }
 
 variable "enable_private_endpoint" {
@@ -71,12 +87,22 @@ variable "master_ipv4_cidr_block" {
 
 variable "monitoring_config" {
   description = "Exposes metrics cluster components."
-  default     = [ "SYSTEM_COMPONENTS" ]
+  default     = null
 }
 
 variable "logging_config" {
   description = "Exposes logs for cluster components."
-  default     = [ "SYSTEM_COMPONENTS" ]
+  default     = null
+}
+
+variable "monitoring_service" {
+  description = "Exposes metrics cluster components."
+  default     = "monitoring.googleapis.com/kubernetes"
+}
+
+variable "logging_service" {
+  description = "Exposes logs for cluster components."
+  default     = "logging.googleapis.com/kubernetes"
 }
 
 variable "vpa_enabled" {
@@ -93,6 +119,12 @@ variable "enable_workload_identity" {
 variable "enable_shielded_nodes" {
   type        = bool
   description = "A boolean to enable cluster-wide shielded nodes"
+  default     = false
+}
+
+variable "enable_intranode_visibility" {
+  type        = bool
+  description = "A boolean to enable intranode-visbility in the cluster"
   default     = false
 }
 

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -124,9 +124,9 @@ resource "google_container_cluster" "cluster" {
 
   maintenance_policy {
     recurring_window {
-      start_time = "1970-01-01T13:00:00Z"
-      end_time = "1970-01-01T21:00:00Z"
-      recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+      start_time = var.maintenance_policy_window_start_time
+      end_time = var.maintenance_policy_window_end_time
+      recurrence = var.maintenance_policy_window_recurrence
     }
   }
 

--- a/vpc-native-beta/main.tf
+++ b/vpc-native-beta/main.tf
@@ -5,15 +5,16 @@ locals {
 }
 
 resource "google_container_cluster" "cluster" {
-  provider              = google-beta
-  name                  = var.name
-  location              = var.region
-  min_master_version    = var.kubernetes_version
-  network               = var.network_name
-  subnetwork            = var.nodes_subnetwork_name
-  enable_shielded_nodes = var.enable_shielded_nodes
-
-
+  provider                    = google-beta
+  name                        = var.name
+  location                    = var.region
+  min_master_version          = var.kubernetes_version
+  network                     = var.network_name
+  subnetwork                  = var.nodes_subnetwork_name
+  enable_shielded_nodes       = var.enable_shielded_nodes
+  enable_intranode_visibility = var.enable_intranode_visibility 
+  monitoring_service          = var.monitoring_service
+  logging_service             = var.logging_service
   vertical_pod_autoscaling {
     enabled = var.vpa_enabled
   }
@@ -38,13 +39,20 @@ resource "google_container_cluster" "cluster" {
     channel = var.release_channel
   }
 
-  logging_config {
-    enable_components = var.logging_config
+  dynamic "logging_config" {
+    for_each = var.logging_config != null ? [1] : []
+    content {
+      enable_components = var.logging_config
+    }
   }
-  monitoring_config {
-    enable_components = var.monitoring_config
-    managed_prometheus {
-      enabled = var.enable_managed_prometheus
+
+  dynamic "monitoring_config" {
+    for_each = var.monitoring_config != null ? [1] : []
+    content {
+      enable_components = var.monitoring_config
+      managed_prometheus {
+        enabled = var.enable_managed_prometheus
+      }
     }
   }
   private_cluster_config {
@@ -115,8 +123,10 @@ resource "google_container_cluster" "cluster" {
   }
 
   maintenance_policy {
-    daily_maintenance_window {
-      start_time = var.maintenance_policy_start_time
+    recurring_window {
+      start_time = "1970-01-01T13:00:00Z"
+      end_time = "1970-01-01T21:00:00Z"
+      recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
     }
   }
 


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

- Allows legacy logging and monitoring policies to be used
- Allows defining intranode visibility 
- Defines a default 9am-5pm Monday-Friday maintenance window 

### What changes did you make?

### What alternative solution should we consider, if any?

